### PR TITLE
ci: cache node_modules and also test against latest Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "node"
 
 addons:
   apt:
@@ -25,7 +26,7 @@ before_install:
   - php --version
   - if [[ $TRAVIS_SECURE_ENV_VARS = "true" ]]; then php -r "readfile('https://getcomposer.org/installer');" | php && php composer.phar config -g github-oauth.github.com $GH_AUTH; fi
 
-install: npm ci
+install: npm install
 
 before_script:
   - phpenv config-rm xdebug.ini
@@ -36,5 +37,6 @@ matrix:
 cache:
   directories:
     - "$HOME/.npm"
+    - "node_modules"
 
 after_script: 'npm run coveralls'


### PR DESCRIPTION
This better reproduces the behavior of the end users where the lockfile is not used.